### PR TITLE
Pass all relevant config params to Bedrock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To install the Bedrock minecraft server, use the helm chart in this repo:
 
 ```bash
 helm install bedrock-server helm/minecraft-bedrock/ \
+    --set minecraftServer.eula=true \
     --set minecraftServer.gameMode="survival" \
     --set minecraftServer.difficulty="normal" \
     --set minecraftServer.whitelist=true \

--- a/helm/minecraft-bedrock/Chart.yaml
+++ b/helm/minecraft-bedrock/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: minecraft-bedrock
-description: A Helm chart for Kubernetes
+description: Minecraft Bedrock server
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/minecraft-bedrock/templates/deployment.yaml
+++ b/helm/minecraft-bedrock/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             periodSeconds: 30
             failureThreshold: 10
             successThreshold: 1
-            timeoutSeconds: 1      
+            timeoutSeconds: 1
           readinessProbe:
             exec:
               command:
@@ -60,37 +60,65 @@ spec:
             periodSeconds: 5
             failureThreshold: 10
             successThreshold: 1
-            timeoutSeconds: 1      
+            timeoutSeconds: 1
           env:
             - name: EULA
-              value: "TRUE"
+              value: {{ .Values.minecraftServer.eula | quote }}
             - name: SERVER_NAME
-              value: {{ .Values.minecraftServer.name | quote }}
+              value: {{ .Values.minecraftServer.serverName | quote }}
             - name: VERSION
               value: {{ .Values.minecraftServer.version | quote }}
+            - name: WHITE_LIST
+              value: {{ default "" .Values.minecraftServer.whitelist | quote }}
+            - name: WHITE_LIST_USERS
+              value: {{ default "" .Values.minecraftServer.whitelistUsers | quote }}
+            - name: OPS
+              value: {{ default "" .Values.minecraftServer.ops | quote }}
+            - name: MEMBERS
+              value: {{ default "" .Values.minecraftServer.members | quote }}
+            - name: VISITORS
+              value: {{ default "" .Values.minecraftServer.visitors | quote }}
+            - name: ALLOW_CHEATS
+              value: {{ .Values.minecraftServer.cheats | quote }}
+            - name: MAX_PLAYERS
+              value: {{ .Values.minecraftServer.maxPlayers | quote }}
+            - name: VIEW_DISTANCE
+              value: {{ .Values.minecraftServer.viewDistance | quote }}
+            - name: TICK_DISTANCE
+              value: {{ .Values.minecraftServer.tickDistance | quote }}
+            - name: PLAYER_IDLE_TIMEOUT
+              value: {{ .Values.minecraftServer.playerIdleTimeout | quote }}
+            - name: MAX_THREADS
+              value: {{ .Values.minecraftServer.maxThreads | quote }}
             - name: GAMEMODE
               value: {{ .Values.minecraftServer.gameMode | quote }}
             - name: DIFFICULTY
               value: {{ .Values.minecraftServer.difficulty | quote }}
-            - name: WHITE_LIST
-              value: {{ .Values.minecraftServer.whitelist | quote }}
-            - name: MAX_PLAYERS
-              value: {{ .Values.minecraftServer.maxPlayers | quote }}
+            - name: LEVEL_TYPE
+              value: {{ .Values.minecraftServer.levelType | quote }}
+            - name: LEVEL_NAME
+              value: {{ .Values.minecraftServer.levelName | quote }}
+            - name: LEVEL_SEED
+              value: {{ default "" .Values.minecraftServer.levelSeed | quote }}
+            - name: DEFAULT_PLAYER_PERMISSION_LEVEL
+              value: {{ .Values.minecraftServer.defaultPermission | quote }}
+            - name: TEXTUREPACK_REQUIRED
+              value: {{ .Values.minecraftServer.texturepackRequired | quote }}
             - name: ONLINE_MODE
               value: {{ .Values.minecraftServer.onlineMode | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          - name: datadir
-            mountPath: /data
+            - name: datadir
+              mountPath: /data
       volumes:
-      - name: datadir
-      {{- if .Values.persistence.dataDir.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ template "minecraft-bedrock.fullname" . }}-datadir
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
+        - name: datadir
+        {{- if .Values.persistence.dataDir.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "minecraft-bedrock.fullname" . }}-datadir
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/minecraft-bedrock/values.yaml
+++ b/helm/minecraft-bedrock/values.yaml
@@ -18,18 +18,62 @@ persistence:
   resourcePolicy: "keep"
 
 minecraftServer:
-  name: "Kubernetes Minecraft (Bedrock)"
-  # One of: LATEST, PREVIOUS, 1.11, 1.12, 1.13, 1.14, 1.16
-  version: "1.16"
-  # Game mode
-  gameMode: "survival"
-  # Game difficulty
-  difficulty: normal
-  # A comma-separated list of player names to whitelist.
+  # This is the server name shown in the in-game server list.
+  serverName: "Kubernetes Minecraft (Bedrock)"
+  # This must be overridden, since we can't accept this for the user.
+  eula: "FALSE"
+  # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
+  version: "LATEST"
+  # One of: peaceful, easy, normal, and hard
+  difficulty: "normal"
+  # A boolean to indicate if whitelist is enabled or not. If this is enabled
+  # and whitelistUsers is left blank, you will need to provide the whitelist.json
+  # file via the volume mounted in to the container. Setting whitelistUsers implies
+  # whitelist is true, so it is not necessary to set it.
   whitelist: true
+  # A comma-separated list of player names to whitelist with no whitespace.
+  # ex: whitelistUsers: player1,player2,player3
+  whitelistUsers:
+  # A comma-separated list of xuid's for operators on server with no
+  # whitespaces.
+  # The server logs will print xuids as players connect.
+  # ex: ops: "12345678,0987654"
+  ops:
+  # A comma-separated list of xuid's for members on server with no
+  # whitespaces.
+  # ex: ops: "12345678,0987654"
+  members:
+  # A comma-separated list of xuid's for visitors on server with no
+  # whitespaces.
+  # ex: ops: "12345678,0987654"
+  visitors:
   # Max connected players.
   maxPlayers: 20
+  # The world is ticked this many chunks away from any player.
+  tickDistance: 6
+  # Max view distance (in chunks).
+  viewDistance: 14
+  # The "level-name" value is used as the world name and its folder name.
+  # The backup sidecar expects "Bedrock level" (in the map generator script)
+  levelName: "Bedrock level"
+  # Define this if you want a specific map generation seed.
+  levelSeed:
+  # One of: creative, survival, adventure, spectator
+  gameMode: "survival"
+  # Permission level for new players joining for the first time (visitor, member, operator)
+  defaultPermission: "member"
+  # After a player has idled for this many minutes they get kicked.
+  playerIdleTimeout: 30
+  # One of: DEFAULT, FLAT, LEGACY
+  levelType: "DEFAULT"
+  # Force clients to use texture packs in the current world
+  texturepackRequired: false
+  # Check accounts against Minecraft account service.
   onlineMode: true
+  # Maximum number of threads the server tries to use. If set to 0 or removed then it uses as many as possible.
+  maxThreads: 0
+  # Cheat like commands can be used.
+  cheats: false
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Add more configurable params to `values.yaml` & helm chart.

Changes in default values:
- EULA is false by default and needs to be explicitly passed at deployment (i.e. `--set minecraftServer.eula=true`)
- Use "LATEST" server version instead of "1.16"

Fixes #4 & minor formatting changes.